### PR TITLE
Register `silvioFlipTopMenu` only when `topMenuMode` is `flip`

### DIFF
--- a/src/sidebar-card.ts
+++ b/src/sidebar-card.ts
@@ -651,13 +651,17 @@ async function build() {
           headerHost!.style.zIndex = '1';
         }
 
-        (window as any).silvioFlipTopMenu = () => {
-          try {
-            triggerHeaderFlip(headerHost!, appLayout, headerWrapper!, viewEl!, flipPauseMs);
-          } catch (_e) {
-            // ignore
-          }
-        };
+        if (topMenuMode === 'flip') {
+          (window as any).silvioFlipTopMenu = () => {
+            try {
+              triggerHeaderFlip(headerHost!, appLayout, headerWrapper!, viewEl!, flipPauseMs);
+            } catch (_e) {
+              // ignore
+            }
+          };
+        } else {
+          delete (window as any).silvioFlipTopMenu;
+        }
 
         if ((window as any).__silvioFlipActive === true) return;
 


### PR DESCRIPTION
### Motivation
- Fix a bug where selecting `push` or `overlay` for `topMenuMode` still left the flip handler active, causing the header to flip unexpectedly.
- Ensure the flip behavior is only available when explicitly configured with `topMenuMode: 'flip'`.

### Description
- Updated `applyHeaderLayout` in `src/sidebar-card.ts` to only assign `window.silvioFlipTopMenu` when `topMenuMode === 'flip'`.
- Remove any existing `window.silvioFlipTopMenu` handler for non-`flip` modes by calling `delete` when appropriate.
- Kept existing guards such as `__silvioFlipActive` and the existing layout adjustments unchanged.

### Testing
- No automated tests were run against this change.
- Changes were limited to a single runtime handler assignment in `src/sidebar-card.ts` and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960eacab6dc8330916bfe6b9bb68a0d)