### PR TITLE
Set hass on header slot cards before calling setConfig

### DIFF
--- a/src/HeaderCard.ts
+++ b/src/HeaderCard.ts
@@ -92,6 +92,7 @@ export class HeaderCard extends LitElement {
       const el: any = document.createElement(tag);
       if (typeof el.setConfig !== 'function') return;
 
+      el.hass = (this.hass ?? getHass()) as any;
       el.setConfig(cardCfg);
       el.hass = (this.hass ?? getHass()) as any;
       container.appendChild(el);


### PR DESCRIPTION
### Motivation
- Mushroom-based chips placed in `centerCard` could lose background or text colors on update because cards may execute `setConfig` before receiving the `hass` object.
- Providing `hass` to the card instance prior to configuration ensures theme-dependent rendering and entity-dependent initialization work correctly.

### Description
- Set `el.hass` before calling `el.setConfig(cardCfg)` in the `_buildCardInto` `createAndAttach` helper.
- Change made in `src/HeaderCard.ts` so header slot cards receive `hass` both when attached immediately and after `customElements.whenDefined`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960fc38c174833087e0e55982b51b2f)